### PR TITLE
Put max_toot_chars back

### DIFF
--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -2,9 +2,14 @@
 
 class InitialStateSerializer < ActiveModel::Serializer
   attributes :meta, :compose, :accounts,
-             :media_attachments, :settings
+             :media_attachments, :settings,
+             :max_toot_chars
 
   has_one :push_subscription, serializer: REST::WebPushSubscriptionSerializer
+  
+  def max_toot_chars
+    StatusLengthValidator::MAX_CHARS
+  end
 
   def meta
     store = {


### PR DESCRIPTION
Update to v2.4.0 messed with the customised character limits of toots.